### PR TITLE
fixing malloc when HLL_BIT_WIDTH is than 13

### DIFF
--- a/libmysqlhll/mysqlhll.cxx
+++ b/libmysqlhll/mysqlhll.cxx
@@ -82,7 +82,7 @@ class Data {
       shll = hll;
 
       if (need_result) {
-        result = (char*)malloc(10000);
+        result = (char*)malloc(std::pow(2,HLL_BIT_WIDTH));
       } else {
         result = NULL;
       }      


### PR DESCRIPTION
Related to https://github.com/amirtuval/mysql-hyperloglog/issues/7

That seems to fix the issue I'm having. I've tried with HLL_BIT_WIDTH 13, 14 and 16 and MySQL didn't crash.

What do you think?

